### PR TITLE
Add test for creating remote base, and fixes bug reproduced in test

### DIFF
--- a/init/init.go
+++ b/init/init.go
@@ -94,7 +94,8 @@ func Init(cfg *Config) error {
 			return err
 		}
 		// TODO: check err on track.Track
-		track.Track(dest, ".gitignore")
+		ignorePath := filepath.Join(dest, ".gitignore")
+		track.Track(dest, ignorePath)
 	}
 
 	fmt.Printf("Initialized empty base at %v\n", dest)

--- a/init/init_test.go
+++ b/init/init_test.go
@@ -1,6 +1,7 @@
 package init
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,6 +16,7 @@ func TestInit(t *testing.T) {
 	if err := os.Mkdir(testdir, os.ModePerm); err != nil {
 		t.Fatal(err)
 	}
+
 	if err := os.Chdir(testdir); err != nil {
 		t.Fatal(err)
 	}
@@ -27,10 +29,10 @@ func TestInit(t *testing.T) {
 			NoModGitIgnore:     false,
 			Force:              true,
 		}
+
 		if err := Init(&cfg); err != nil {
 			t.Fatal(err)
 		}
-
 	})
 
 	if err := os.Chdir(wd); err != nil {
@@ -39,4 +41,34 @@ func TestInit(t *testing.T) {
 	if err := os.RemoveAll(testdir); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// Tests that you can call cfg init /some/other/path/far/far/away
+func TestInitOverThere(t *testing.T) {
+	// creating a temporary directory in /tmp in case os.exit gets called and
+	// we don't have a chance to cleanup
+	testdir, err := ioutil.TempDir("", "testdir")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// automatic cleanup of testing directory
+	// NOTE: does not work if os.exit is called.
+	defer os.RemoveAll(testdir)
+
+	t.Run("--force", func(t *testing.T) {
+		defer os.RemoveAll(testdir)
+		cfg := Config{
+			AppendGitIgnore:    false,
+			OverwriteGitIgnore: false,
+			NoGit:              false,
+			NoModGitIgnore:     false,
+			Force:              true,
+			Dest:               testdir,
+		}
+
+		if err := Init(&cfg); err != nil {
+			t.Fatal(err)
+		}
+	})
 }


### PR DESCRIPTION
Essentially, the bug here was that when we called track on the gitignore file, it assumed that we were creating the gitignore file in the current working directory. We now track it off the bat in the remote directory.

Not sure if this is actually the right fix or if it just makes the error go away, but I'm sure you'll know @thomasdfischer 