### PR TITLE
make LS print filenames relative to base directory

### DIFF
--- a/dotcfg/cfgfile.go
+++ b/dotcfg/cfgfile.go
@@ -29,6 +29,7 @@ func NewCfg() *File {
 		Instances:  make([]Instance, 0),
 		Singletons: make([]Singleton, 0),
 		NoGit:      false,
+		BaseDir:    "",
 	}
 }
 
@@ -44,6 +45,8 @@ func LoadCfg(baseDir string) (*File, error) {
 	if err := json.NewDecoder(f).Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse %v\n", filePath)
 	}
+	cfg.BaseDir = baseDir
+
 	return &cfg, nil
 }
 

--- a/dotcfg/paths.go
+++ b/dotcfg/paths.go
@@ -44,3 +44,32 @@ func GetAbsAndRelPaths(baseDir, filePath string) (string, string, error) {
 	}
 	return filepath.Join(baseDir, relPath), relPath, nil
 }
+
+// ConvertPathToRelative takes in a filepath, and returns the
+// full relative filepath, even if the filepath is not a child path.
+// This detects the current working directory when it computes the relative
+// path.
+func ConvertPathToRelative(filePath string) (string, error) {
+	if len(filePath) == 0 {
+		return "", fmt.Errorf("filepath is an empty string")
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	if !filepath.IsAbs(filePath) {
+		filePath, err = filepath.Abs(filePath)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	rel, err := filepath.Rel(cwd, filePath)
+	if err != nil {
+		return "", err
+	}
+
+	return rel, nil
+}

--- a/dotcfg/tests/paths_test.go
+++ b/dotcfg/tests/paths_test.go
@@ -12,22 +12,22 @@ import (
 
 func TestConvertPathToRelative(t *testing.T) {
 	tests := []struct {
-		cwd          string
+		baseDir      string
 		filePath     string
 		relativePath string
 		err          error
 	}{
-		{cwd: "/", filePath: "/a", relativePath: "a", err: nil},
-		{cwd: "/", filePath: "/a/b", relativePath: "a/b", err: nil},
-		{cwd: "/a/b", filePath: "/c", relativePath: "../../c", err: nil},
-		{cwd: "/", filePath: "/", relativePath: ".", err: nil},
+		{baseDir: "/", filePath: "/a", relativePath: "a", err: nil},
+		{baseDir: "/", filePath: "/a/b", relativePath: "a/b", err: nil},
+		{baseDir: "/a/b", filePath: "/c", relativePath: "../../c", err: nil},
+		{baseDir: "/", filePath: "/", relativePath: ".", err: nil},
 	}
 
 	for _, test := range tests {
 		tempDir := os.TempDir()
 		defer os.RemoveAll(tempDir)
 
-		testDir := filepath.Join(tempDir, test.cwd)
+		testDir := filepath.Join(tempDir, test.baseDir)
 
 		testPath := test.filePath
 		if filepath.IsAbs(test.filePath) {

--- a/dotcfg/tests/paths_test.go
+++ b/dotcfg/tests/paths_test.go
@@ -1,0 +1,56 @@
+package dotcfg
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Confbase/cfg/dotcfg"
+	"github.com/magiconair/properties/assert"
+)
+
+func TestConvertPathToRelative(t *testing.T) {
+	tests := []struct {
+		cwd          string
+		filePath     string
+		relativePath string
+		err          error
+	}{
+		{cwd: "/", filePath: "/a", relativePath: "a", err: nil},
+		{cwd: "/", filePath: "/a/b", relativePath: "a/b", err: nil},
+		{cwd: "/a/b", filePath: "/c", relativePath: "../../c", err: nil},
+		{cwd: "/", filePath: "/", relativePath: ".", err: nil},
+	}
+
+	for _, test := range tests {
+		tempDir := os.TempDir()
+		defer os.RemoveAll(tempDir)
+
+		testDir := filepath.Join(tempDir, test.cwd)
+
+		testPath := test.filePath
+		if filepath.IsAbs(test.filePath) {
+			testPath = filepath.Join(tempDir, test.filePath)
+		}
+
+		err := os.MkdirAll(testDir, 0700)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		baseTestDirs := strings.Split(testDir, "/")
+		if len(baseTestDirs) >= 2 {
+			defer os.RemoveAll(filepath.Join(tempDir, baseTestDirs[1]))
+		}
+
+		err = os.Chdir(testDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		relativePath, err := dotcfg.ConvertPathToRelative(testPath)
+		assert.Equal(t, test.relativePath, relativePath)
+		assert.Equal(t, test.err, err)
+	}
+}

--- a/dotcfg/types.go
+++ b/dotcfg/types.go
@@ -24,6 +24,7 @@ type File struct {
 	Instances  []Instance  `json:"instances"`
 	Singletons []Singleton `json:"singletons"`
 	NoGit      bool        `json:"noGit"`
+	BaseDir    string
 }
 
 type Singleton struct {

--- a/ls/ls.go
+++ b/ls/ls.go
@@ -3,6 +3,7 @@ package ls
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/crypto/ssh/terminal"
@@ -85,7 +86,13 @@ func LsTemplsHuman(cfg *dotcfg.File, d *decorate.Decorator) {
 	fmt.Println(d.LightBlue(d.Title("templates")))
 	if len(cfg.Templates) > 0 {
 		for _, t := range cfg.Templates {
-			fmt.Printf("%v: %v\n", d.Green(t.Name), t.FilePath)
+			relativePath, err := dotcfg.ConvertPathToRelative(filepath.Join(cfg.BaseDir, t.FilePath))
+			if err != nil {
+				// This seems somewhat hacky... but I'm not sure how best to handle this
+				relativePath = t.FilePath
+			}
+
+			fmt.Printf("%v: %v\n", d.Green(t.Name), relativePath)
 		}
 	}
 }
@@ -93,7 +100,13 @@ func LsTemplsHuman(cfg *dotcfg.File, d *decorate.Decorator) {
 func LsTemplsTty(cfg *dotcfg.File) {
 	fmt.Println("templates")
 	for _, t := range cfg.Templates {
-		fmt.Printf("%v\t%v\n", t.Name, t.FilePath)
+		relativePath, err := dotcfg.ConvertPathToRelative(filepath.Join(cfg.BaseDir, t.FilePath))
+		if err != nil {
+			// This seems somewhat hacky... but I'm not sure how best to handle this
+			relativePath = t.FilePath
+		}
+
+		fmt.Printf("%v\t%v\n", t.Name, relativePath)
 	}
 }
 
@@ -102,7 +115,13 @@ func LsInstsHuman(cfg *dotcfg.File, d *decorate.Decorator) {
 	if len(cfg.Templates) > 0 {
 		for _, inst := range cfg.Instances {
 			templsStr := strings.Join(inst.TemplNames, ", ")
-			fmt.Printf("%v: %v\n", d.Green(inst.FilePath), templsStr)
+			relativePath, err := dotcfg.ConvertPathToRelative(filepath.Join(cfg.BaseDir, inst.FilePath))
+			if err != nil {
+				// This seems somewhat hacky... but I'm not sure how best to handle this
+				relativePath = inst.FilePath
+			}
+
+			fmt.Printf("%v: %v\n", d.Green(relativePath), templsStr)
 		}
 	}
 }
@@ -111,21 +130,39 @@ func LsInstsTty(cfg *dotcfg.File) {
 	fmt.Println("instances")
 	for _, inst := range cfg.Instances {
 		templsStr := strings.Join(inst.TemplNames, ",")
-		fmt.Printf("%v\t%v\n", inst.FilePath, templsStr)
+		relativePath, err := dotcfg.ConvertPathToRelative(filepath.Join(cfg.BaseDir, inst.FilePath))
+		if err != nil {
+			// This seems somewhat hacky... but I'm not sure how best to handle this
+			relativePath = inst.FilePath
+		}
+
+		fmt.Printf("%v\t%v\n", relativePath, templsStr)
 	}
 }
 
 func LsSinglesHuman(cfg *dotcfg.File, d *decorate.Decorator) {
 	fmt.Println(d.LightBlue(d.Title("singletons")))
 	for _, s := range cfg.Singletons {
-		fmt.Printf("%v\n", s.FilePath)
+		relativePath, err := dotcfg.ConvertPathToRelative(filepath.Join(cfg.BaseDir, s.FilePath))
+		if err != nil {
+			// This seems somewhat hacky... but I'm not sure how best to handle this
+			relativePath = s.FilePath
+		}
+
+		fmt.Printf("%v\n", relativePath)
 	}
 }
 
 func LsSinglesTty(cfg *dotcfg.File) {
 	fmt.Println("singletons")
 	for _, s := range cfg.Singletons {
-		fmt.Println(s.FilePath)
+		relativePath, err := dotcfg.ConvertPathToRelative(filepath.Join(cfg.BaseDir, s.FilePath))
+		if err != nil {
+			// This seems somewhat hacky... but I'm not sure how best to handle this
+			relativePath = s.FilePath
+		}
+
+		fmt.Println(relativePath)
 	}
 }
 


### PR DESCRIPTION
Here's the current status: 
```
drake@element:~/workspace/test_base$ cfg ls
## master
templates
config: config.yaml

instances
config_dev1.yaml: config
config_dev2.yaml: config
another_one.yaml: config
yet_another_one.yaml: config
yeet_another_one.yaml: config
yeeet_another_one.yaml: config
yeeeet_another_one.yaml: config
yeeeeet_another_one.yaml: config
yeeeeeet_another_one.yaml: config
yeeeeeeet_another_one.yaml: config
yeeeeeeeet_another_one.yaml: config
yeeeeeeeeet_another_one.yaml: config
yeeeeeeeeeet_another_one.yaml: config
not_another_one.yaml: config
yet_not_another_one.yaml: config
yeet_not_another_one.yaml: config
another_test_config.yaml: config
yet_another_test_config.yaml: config
testy.yaml: config
teesty.yaml: config
teeesty.yaml: config

singletons
.gitignore
drake@element:~/workspace/test_base$ cd lol/test/heck/
drake@element:~/workspace/test_base/lol/test/heck$ cfg ls
## master
templates
config: ../../../config.yaml

instances
../../../config_dev1.yaml: config
../../../config_dev2.yaml: config
../../../another_one.yaml: config
../../../yet_another_one.yaml: config
../../../yeet_another_one.yaml: config
../../../yeeet_another_one.yaml: config
../../../yeeeet_another_one.yaml: config
../../../yeeeeet_another_one.yaml: config
../../../yeeeeeet_another_one.yaml: config
../../../yeeeeeeet_another_one.yaml: config
../../../yeeeeeeeet_another_one.yaml: config
../../../yeeeeeeeeet_another_one.yaml: config
../../../yeeeeeeeeeet_another_one.yaml: config
../../../not_another_one.yaml: config
../../../yet_not_another_one.yaml: config
../../../yeet_not_another_one.yaml: config
../../../another_test_config.yaml: config
../../../yet_another_test_config.yaml: config
../../../testy.yaml: config
../../../teesty.yaml: config
../../../teeesty.yaml: config

singletons
../../../.gitignore
```

This works fine if all the files are in the base directory, but it doesn't work if we were to, say, put the config files in a directory. I'm not sure if this is intended functionality or not, but if we want to support files in directories within the base, we'll need to add some more metadata (relative path to config files from base directory, pretty easy add)

#53 